### PR TITLE
Expose essential demand control data points

### DIFF
--- a/daikin.js
+++ b/daikin.js
@@ -554,7 +554,9 @@ async function storeDaikinData(err) {
         updated += await handleDaikinUpdate(control, 'control');
         updated += await handleDaikinUpdate(controlInfo, 'controlInfo');
         updated += await handleDaikinUpdate(daikinDevice.currentACSensorInfo, 'sensorInfo');
-        updated += await handleDaikinUpdate(daikinDevice.currentACDemandControl, 'demandControl');
+        if (daikinDevice.currentACDemandControl) {
+            updated += await handleDaikinUpdate(daikinDevice.currentACDemandControl, 'demandControl');
+        }
         if (updated > 0) {
             adapter.log.info(`${updated} Values updated`);
         }

--- a/daikin.js
+++ b/daikin.js
@@ -41,10 +41,13 @@ const SpecialMode = {
     '12/13': 'ECONO/STREAMER'
 };
 
+const DemandControlMode = {'0': 'MANUAL', '1': 'TIMER', '2': 'AUTO'};
+
 const channelDef = {
     'deviceInfo': {'role': 'info'},
     'control': {'role': 'thermo'},
     'controlInfo': {'role': 'info'},
+    'demandControl': {'role': 'info'},
     'modelInfo': {'role': 'info'},
     'sensorInfo': {'role': 'info'}
 };
@@ -190,6 +193,19 @@ const fieldDef = {
         'fanDirectionB': {'role': 'value', 'read': true, 'write': false, 'type': 'number', 'states': FanDirection},
 
         'error': {'role': 'value', 'read': true, 'write': false, 'type': 'number'}		// 255
+    },
+    'demandControl': {
+        'enabled': {'role': 'switch', 'read': true, 'write': false, 'type': 'boolean'}, // can be writable later
+        'mode': {'role': 'level', 'read': true, 'write': false, 'type': 'number', 'states': DemandControlMode}, // can be writable later
+        'maxPower': {
+            'role': 'level.power',
+            'read': true,
+            'write': false, // will be writable
+            'type': 'number',
+            'min': 40,
+            'max': 100,
+            'unit': '%'
+        },		// number from 40..100 and must be a multiply of 5
     },
     'modelInfo': {
         'model': {'role': 'text', 'read': true, 'write': false, 'type': 'string'},
@@ -536,6 +552,7 @@ async function storeDaikinData(err) {
         updated += await handleDaikinUpdate(control, 'control');
         updated += await handleDaikinUpdate(controlInfo, 'controlInfo');
         updated += await handleDaikinUpdate(daikinDevice.currentACSensorInfo, 'sensorInfo');
+        updated += await handleDaikinUpdate(daikinDevice.currentACDemandControl, 'demandControl');
         if (updated > 0) {
             adapter.log.info(`${updated} Values updated`);
         }

--- a/daikin.js
+++ b/daikin.js
@@ -41,6 +41,7 @@ const SpecialMode = {
     '12/13': 'ECONO/STREAMER'
 };
 
+const DemandControlType = {'0': 'UNSUPPORTED', '1': 'SUPPORTED'};
 const DemandControlMode = {'0': 'MANUAL', '1': 'TIMER', '2': 'AUTO'};
 
 const channelDef = {
@@ -196,6 +197,7 @@ const fieldDef = {
     },
     'demandControl': {
         'enabled': {'role': 'switch', 'read': true, 'write': false, 'type': 'boolean'}, // can be writable later
+        'type': {'role': 'level', 'read': true, 'write': false, 'type': 'number', 'states': DemandControlType},
         'mode': {'role': 'level', 'read': true, 'write': false, 'type': 'number', 'states': DemandControlMode}, // can be writable later
         'maxPower': {
             'role': 'level.power',


### PR DESCRIPTION
Closes #183

It also depends on PR Apollon77/daikin-controller#268 .

For now only the minimum needed for later control is exposed:

- enabled: to be able to activate or deactivate demand control
- mode: to be able to change the modes MANUAL, AUTO (, SCHEDULE)
- max_power: to be able to change maximum power percentage of demand control

Not exposed:

- type: meaning unknown; and must be always 1
- schedule information: support is complex and is not really an automation use case in my opinion

Open Issue: at least "maxPower" (but possibly also "mode" and "enabled") will be writable later. In this PR they are placed in their own group "demandControl".
On the other hand, the current adapter bundles all writable data points within the "control" group.

With this PR I could replace the usage of "daikin-cloud.0..climateControl.demandControl.modes.fixed" in my dashboards.