### PR TITLE
Set demand control percentage

### DIFF
--- a/daikin.js
+++ b/daikin.js
@@ -554,7 +554,9 @@ async function storeDaikinData(err) {
         updated += await handleDaikinUpdate(control, 'control');
         updated += await handleDaikinUpdate(controlInfo, 'controlInfo');
         updated += await handleDaikinUpdate(daikinDevice.currentACSensorInfo, 'sensorInfo');
-        updated += await handleDaikinUpdate(daikinDevice.currentACDemandControl, 'demandControl');
+        if (daikinDevice.currentACDemandControl) {
+            updated += await handleDaikinUpdate(daikinDevice.currentACDemandControl, 'demandControl');
+        }
         if (updated > 0) {
             adapter.log.info(`${updated} Values updated`);
         }

--- a/daikin.js
+++ b/daikin.js
@@ -41,10 +41,13 @@ const SpecialMode = {
     '12/13': 'ECONO/STREAMER'
 };
 
+const DemandControlMode = {'0': 'MANUAL', '1': 'TIMER', '2': 'AUTO'};
+
 const channelDef = {
     'deviceInfo': {'role': 'info'},
     'control': {'role': 'thermo'},
     'controlInfo': {'role': 'info'},
+    'demandControl': {'role': 'info'},
     'modelInfo': {'role': 'info'},
     'sensorInfo': {'role': 'info'}
 };
@@ -190,6 +193,19 @@ const fieldDef = {
         'fanDirectionB': {'role': 'value', 'read': true, 'write': false, 'type': 'number', 'states': FanDirection},
 
         'error': {'role': 'value', 'read': true, 'write': false, 'type': 'number'}		// 255
+    },
+    'demandControl': {
+        'enabled': {'role': 'switch', 'read': true, 'write': false, 'type': 'boolean'}, // can be writable later
+        'mode': {'role': 'level', 'read': true, 'write': false, 'type': 'number', 'states': DemandControlMode}, // can be writable later
+        'maxPower': {
+            'role': 'level.power',
+            'read': true,
+            'write': false, // will be writable
+            'type': 'number',
+            'min': 40,
+            'max': 100,
+            'unit': '%'
+        },		// number from 40..100 and must be a multiply of 5
     },
     'modelInfo': {
         'model': {'role': 'text', 'read': true, 'write': false, 'type': 'string'},
@@ -536,6 +552,7 @@ async function storeDaikinData(err) {
         updated += await handleDaikinUpdate(control, 'control');
         updated += await handleDaikinUpdate(controlInfo, 'controlInfo');
         updated += await handleDaikinUpdate(daikinDevice.currentACSensorInfo, 'sensorInfo');
+        updated += await handleDaikinUpdate(daikinDevice.currentACDemandControl, 'demandControl');
         if (updated > 0) {
             adapter.log.info(`${updated} Values updated`);
         }

--- a/daikin.js
+++ b/daikin.js
@@ -510,8 +510,6 @@ function main() {
 }
 
 async function storeDaikinData(err) {
-    let updated = 0;
-
     if (stopped) return;
     if (!err) {
         setConnected(true);
@@ -563,16 +561,18 @@ async function storeDaikinData(err) {
             delete basicInfo.power;
         }
 
-        updated += await handleDaikinUpdate(basicInfo, 'deviceInfo');
-        updated += await handleDaikinUpdate(daikinDevice.currentACModelInfo, 'modelInfo');
-        updated += await handleDaikinUpdate(control, 'control');
-        updated += await handleDaikinUpdate(controlInfo, 'controlInfo');
-        updated += await handleDaikinUpdate(daikinDevice.currentACSensorInfo, 'sensorInfo');
+        let updated = {};
+        updated.deviceInfo = await handleDaikinUpdate(basicInfo, 'deviceInfo');
+        updated.modelInfo = await handleDaikinUpdate(daikinDevice.currentACModelInfo, 'modelInfo');
+        updated.control = await handleDaikinUpdate(control, 'control');
+        updated.controlInfo = await handleDaikinUpdate(controlInfo, 'controlInfo');
+        updated.sensorInfo = await handleDaikinUpdate(daikinDevice.currentACSensorInfo, 'sensorInfo');
         if (daikinDevice.currentACDemandControl) {
-            updated += await handleDaikinUpdate(daikinDevice.currentACDemandControl, 'demandControl');
+            updated.demandControl = await handleDaikinUpdate(daikinDevice.currentACDemandControl, 'demandControl');
         }
-        if (updated > 0) {
-            adapter.log.info(`${updated} Values updated`);
+        let updatedTotal = Object.values(updated).reduce((sum, num) => { return sum + num }, 0);
+        if (updatedTotal > 0) {
+            adapter.log.info(`${updatedTotal} Values updated: ${JSON.stringify(updated)}`);
         }
     }
     else {

--- a/daikin.js
+++ b/daikin.js
@@ -41,6 +41,7 @@ const SpecialMode = {
     '12/13': 'ECONO/STREAMER'
 };
 
+const DemandControlType = {'0': 'UNSUPPORTED', '1': 'SUPPORTED'};
 const DemandControlMode = {'0': 'MANUAL', '1': 'TIMER', '2': 'AUTO'};
 
 const channelDef = {
@@ -196,6 +197,7 @@ const fieldDef = {
     },
     'demandControl': {
         'enabled': {'role': 'switch', 'read': true, 'write': false, 'type': 'boolean'}, // can be writable later
+        'type': {'role': 'level', 'read': true, 'write': false, 'type': 'number', 'states': DemandControlType},
         'mode': {'role': 'level', 'read': true, 'write': false, 'type': 'number', 'states': DemandControlMode}, // can be writable later
         'maxPower': {
             'role': 'level.power',

--- a/daikin.js
+++ b/daikin.js
@@ -202,7 +202,7 @@ const fieldDef = {
         'maxPower': {
             'role': 'level.power',
             'read': true,
-            'write': false, // will be writable
+            'write': true,
             'type': 'number',
             'min': 40,
             'max': 100,

--- a/daikin.js
+++ b/daikin.js
@@ -486,6 +486,7 @@ function main() {
                 storeDaikinData(err);
             });
             adapter.subscribeStates('control.*');
+            adapter.subscribeStates('demandControl.*');
         }
         else {
             setConnected(false);


### PR DESCRIPTION
This PR is on top of #184.

It also depends on PRs Apollon77/daikin-controller#268 and Apollon77/daikin-controller#269.

For now only change of demand control percentage is supported.

This PR contains one part under discussion because the new writable parameter "maxPower" does not belong to group "control" but to "demandControl". Since all writable parameter names itself are unique it is enough to check with the second namespace and strip it off. The rest of the logic stays the same.

With this PR I could replace the usage of "daikin-cloud.0.<uuid>.climateControl.demandControl.modes.fixed" in my scripts.